### PR TITLE
Decouple consent layer auto login from theme

### DIFF
--- a/js/consent.js
+++ b/js/consent.js
@@ -1,0 +1,55 @@
+
+/**
+ * Find our login in the list of alternative logins
+ * @returns null if no delegated login is available
+ */
+function getDelegatedLogin() {
+    try {
+        // FIXME remove legacy way to access initialState, use typescript
+        // and 
+        // import { loadState } from '@nextcloud/initial-state'
+        // const val = loadState('myapp', 'user_preference')
+        const logins = OCP.InitialState.loadState('core', 'alternativeLogins');
+        const tlogin = logins.find((login) => login.name.toLowerCase().includes('telekom'));
+        return (tlogin !== null) ? tlogin.href : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function hideLogins() {
+    const mainTags = document.getElementsByTagName('main');
+    if (mainTags !== null) {
+        mainTags[0].style.visibility = "hidden";
+    }
+}
+
+/**
+ * This is the auto login delegate sequence for utag
+ */
+window.addEventListener('DOMContentLoaded', function() {
+   const loginParams = new URLSearchParams(window.location.search);
+   const isDefaultLoginPage = ( window.location.pathname.endsWith('/login') &&
+                             !loginParams.has('direct', '1') );                             
+    if (isDefaultLoginPage) {
+        // only if I am on the default login page (and not ?direct=1 or guest)
+        const delegatedLoginUrl = getDelegatedLogin()
+        if (delegatedLoginUrl !== null) {
+            // only if an alternate, delegated login is available
+            hideLogins();
+
+            // redirect to delegate login after consent selection
+            window.addEventListener("consentChanged", function () {
+                window.location.href = delegatedLoginUrl ;
+            });
+
+            // or redirect directly after page load 
+            // if utag lib is available and consent is already given
+            if ("object" === typeof utag && 
+                "object" === typeof utag.gdpr &&
+                utag.gdpr.getConsentState() !== 0) {
+                    window.location.href = delegatedLoginUrl ;                
+            }
+        }
+    }
+});

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,6 +8,8 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCA\NmcMarketing\Listener\BeforeTemplateRenderedListener;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'nmc_marketing';
@@ -17,8 +19,9 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
-		//Register the CSPListener
+		//Register the CSPListener and consent layer redirect brake
 		$context->registerEventListener(AddContentSecurityPolicyEvent::class, CSPListener::class);
+        $context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 T-Systems International
+ *
+ * @author B. Rederlechner <bernd.rederlechner@t-systems.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\NmcMarketing\Listener;
+
+use OC_App;
+use OCP\AppFramework\Http;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+
+use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+
+class BeforeTemplateRenderedListener implements IEventListener {
+    private IConfig $config;
+    private ContentSecurityPolicyNonceManager $nonceManager;
+
+	public function __construct(
+        IConfig $config,
+        ContentSecurityPolicyNonceManager $nonceManager
+	) {
+        $this->config = $config;
+        $this->nonceManager = $nonceManager;
+	}
+
+	public function handle(Event $event): void {
+		$response = $event->getResponse();
+
+
+        $marketing_config = $this->config->getSystemValue("nmc_marketing");
+        $utagUrl = $marketing_config['url']; 
+        // the marketing tooling is controlled by CSP, so save nonce is mandatory
+        $nonce = $this->nonceManager->getNonce();
+        // we want to invalidate script url remotely with cachebuster
+        $cacheBusterVal = $this->config->getAppValue('theming', 'cachebuster', '0');
+
+        // add utag from external CDN
+		\OCP\Util::addHeader("script", 
+                            [ 'nonce' => $nonce,
+                              'src' =>  $utagUrl . '?nmcv=' . $cacheBusterVal], 
+                              ''); // the empty text is needed to generate HTML5 valid tags
+        
+        // add marketing tracking magic
+        \OCP\Util::addScript("nmc_marketing", "consent");
+	}
+}


### PR DESCRIPTION
The implementation of the consent layer from V24 is made independent of any Nextcloud template.
This brings the following improvements:
- the handling is enable/disabled with nmc_marketing app
- all parameters are in a single server config under nmc_marketing. Example config:
```
marketing.config.php:
<?php

$CONFIG = [
  'nmc_marketing' => array(
    'url' => 'https://tags-eu.tiqcdn.com/utag/telekom/mediencenter/prod/utag.js',
    'trusted_font_urls' =>
        array( 0 => 'https://ebs10.telekom.de/opt-in/' ),
    'trusted_image_urls' =>
        array( 0 => 'https://pix.telekom.de/',
               1=>'http://fbc.wcfbc.net/'),
    'trusted_script_urls' => array( 0 => 'https://tags-eu.tiqcdn.com',
                                    1 =>'https://cdn.wbtrk.net',
                                    2=>'https://geid.wbtrk.net' ),
  ),
];
```
- the login redirection is derived from initial state; auto-login redirect mechanism is only activated if an alternative OpenID login is available for Telekom

TODO: Migrate to typescript and use non-legal initial state handling with new Nextcloud typescript libraries.