### PR TITLE
added mobile clients check in BeforeTemplateRenderedListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ Add below in server config
 'trusted_font_urls'=>array(0 => 'https://ebs10.telekom.de/opt-in/',),
 'trusted_image_urls'=>array(0 => 'https://pix.telekom.de/',1=>'http://fbc.wcfbc.net/',)
 
+```php
+// config/config.php
+    ...,
+    // In order to deactivate the consent layer for the mobile clients we have to configure the identifiable user agents of those clients
+    'nmc_marketing.mobile_user_agents' => [
+        '/^Mozilla\/5\.0 \(Android\) Nextcloud\-android\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/',
+        '/^Mozilla\/5\.0 \(iOS\) Nextcloud\-iOS\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/',
+    ]
+```
 
 ### App Repository 
 https://github.com/nextmcloud/nmc_marketing/tree/nmcfeat/master

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
     <category>customization</category>
     <bugs>https://github.com/nextmcloud/nmc_marketing/issues</bugs>
     <dependencies>
-        <nextcloud min-version="15" max-version="27"/>
+        <nextcloud min-version="15" max-version="28"/>
     </dependencies>
 </info>
 

--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -24,17 +24,17 @@ class BeforeTemplateRenderedListener implements IEventListener {
 	private array $mobileUserAgents;
 
 	public function __construct(
-			IConfig $config,
-			IRequest $request,
-			ContentSecurityPolicyNonceManager $nonceManager
+		IConfig $config,
+		IRequest $request,
+		ContentSecurityPolicyNonceManager $nonceManager
 	) {
-			$this->config = $config;
-			$this->request = $request;
-			$this->nonceManager = $nonceManager;
-			$this->mobileUserAgents = $config->getSystemValue('nmc_marketing.mobile_user_agents', [
-				'/^Mozilla\/5\.0 \(Android\) Nextcloud\-android\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/',
-				'/^Mozilla\/5\.0 \(iOS\) Nextcloud\-iOS\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/',
-			]);
+		$this->config = $config;
+		$this->request = $request;
+		$this->nonceManager = $nonceManager;
+		$this->mobileUserAgents = $config->getSystemValue('nmc_marketing.mobile_user_agents', [
+			'/^Mozilla\/5\.0 \(Android\) Nextcloud\-android\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/',
+			'/^Mozilla\/5\.0 \(iOS\) Nextcloud\-iOS\/(?<version>(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)).*$/',
+		]);
 	}
 
 	public function handle(Event $event): void {


### PR DESCRIPTION
In order to prevent the consent layer from being opened unintentionally within the mobile clients, we check before loading the tealium scripts whether the call was started from one of the mobile apps. 
In this case the inclusion of the script files is suppressed.